### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs @ file:///root/.cache/pypoetry/artifacts/1a/aa/39/10d6d07084f186f8cf6963cb
 autopep8==1.5.7
 backports.entry-points-selectable==1.1.0
 beautifulsoup4==4.10.0
-certifi==2021.5.30
+certifi==2022.12.07
 cfgv==3.3.1
 charset-normalizer==2.0.6
 colorama @ file:///root/.cache/pypoetry/artifacts/b0/f3/a3/cf94f06cbe1d286a25116cfe54d5a75cb1c4b54d15b2b1b4fc03a7f657/colorama-0.4.4-py2.py3-none-any.whl


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2021.5.30
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2021.5.30 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS